### PR TITLE
pin numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "bioformats_jar", 
   "dask[array]>=2021.4.1,<=2023.5.0",
   "fsspec>=2022.8.0",
-  "numpy>=1.21",
+  "numpy>=1.21,<2.0.0",
   "ome-types>=0.3.4",
   "resource-backed-dask-array>=0.1.0",
 ]


### PR DESCRIPTION

## Core Issue
The purpose of this PR is to investigate some improper metadata reading for the bioformats reader. As can be seen[ here ](https://github.com/bioio-devs/bioio-bioformats/actions/runs/9553652459/job/26332947295). The channels for the Imaris image are being read as ['Red', 'Green', 'Blue'] rather than ['Channel:0:0', 'Channel:0:1','Channel:0:2']. The weird part Is that I cannot replicate this locally. I originally assumed that this was a dependency issue ( This is what led me to pin Numpy, see below). However with the exact dependencies and confirming that the download hash is the same for test files I still have not been able to replicate this locally.


## Notes 
1) numpy 2.0.0 moves from np.round_ to np.round. dask.array still uses np.round_ raising AttributeError: `np.round_` was removed in the NumPy 2.0 release. Use `np.round` instead. I have pinned Numpy to look at the deeper issue.
2) This issue seems to have been seen before here #10 however the logs have expired so I cannot tell 100% that it is the same issue.