### PR TITLE
bugfix/remove-dask-upper-bound

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,8 @@ jobs:
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install .[test]
+        pip install uv
+        uv pip install .[test]
     - uses: actions/cache@v3
       id: cache
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install uv
-        uv pip install .[test]
+        uv pip install --system .[test]
     - uses: actions/cache@v3
       id: cache
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dynamic = ["version"]
 dependencies = [
   "bioio-base>=0.3.0",
   "bioformats_jar", 
-  "dask[array]>=2021.4.1,<=2023.5.0",
+  "dask[array]>=2021.4.1",
   "fsspec>=2022.8.0",
   "numpy>=1.21",
   "ome-types>=0.3.4",


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue

This pull request resolves #14

### Description of Changes

<!-- Include a description of the proposed changes. -->

The issue isn't that numpy has an error its that dask is bounded. At least, `bioio` tests complete just fine using the latest version.

I don't have access to the test files anymore so opening this PR to have tests run things for me.

Only other change is I added [uv](https://github.com/astral-sh/uv) to the CI job to make installing dependencies much much much faster.