### PR TITLE
Allow errors to become visible

### DIFF
--- a/bioio_bioformats/reader.py
+++ b/bioio_bioformats/reader.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import logging
 from functools import cached_property
 from typing import Any, Dict, Optional, Tuple, Union
 
@@ -14,6 +15,7 @@ from . import utils
 from .biofile import BioFile
 
 ###############################################################################
+log = logging.getLogger(__name__)
 
 
 class Reader(reader.Reader):
@@ -91,17 +93,23 @@ class Reader(reader.Reader):
         -------
         is_supported: bool
             True if the file is supported by bioformats, false otherwise
-
         Notes
-        -----
-        Throw an exception if the file is not supported by bioformats.
-        As of 2025-05-01, bio handles that and logs appropriately.
+        logs warnings with as much information as is available as to why the file is
+        not supported.
         """
-        if not isinstance(fs, LocalFileSystem):
-            raise ValueError("Cannot read Bioformats from non-local file system.")
-        f = BioFile(path, meta=False, memoize=False)
-        f.close()
-        return True
+        try:
+            if not isinstance(fs, LocalFileSystem):
+                log.warning("Cannot read files from non-local file system.")
+                return False
+            f = BioFile(path, meta=False, memoize=False)
+            f.close()
+            return True
+        except Exception as e:
+            log.warning(
+                f"Exception raised while checking if {path} is supported by bioformats."
+            )
+            log.exception(e)
+            return False
 
     def __init__(
         self,

--- a/bioio_bioformats/reader.py
+++ b/bioio_bioformats/reader.py
@@ -86,15 +86,22 @@ class Reader(reader.Reader):
 
     @staticmethod
     def _is_supported_image(fs: AbstractFileSystem, path: str, **kwargs: Any) -> bool:
-        try:
-            if not isinstance(fs, LocalFileSystem):
-                return False
-            f = BioFile(path, meta=False, memoize=False)
-            f.close()
-            return True
+        """
+        Returns
+        -------
+        is_supported: bool
+            True if the file is supported by bioformats, false otherwise
 
-        except Exception:
-            return False
+        Notes
+        -----
+        Throw an exception if the file is not supported by bioformats.
+        As of 2025-05-01, bio handles that and logs appropriately.
+        """
+        if not isinstance(fs, LocalFileSystem):
+            raise ValueError("Cannot read Bioformats from non-local file system.")
+        f = BioFile(path, meta=False, memoize=False)
+        f.close()
+        return True
 
     def __init__(
         self,

--- a/bioio_bioformats/tests/test_reader.py
+++ b/bioio_bioformats/tests/test_reader.py
@@ -69,6 +69,17 @@ from .conftest import LOCAL_RESOURCES_DIR
             ["EGFP", "TaRFP", "Bright"],
             (1.0, 1.0833333333333333, 1.0833333333333333),
         ),
+        pytest.param(  # missing file
+            "doesNotExist.txt",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            marks=pytest.mark.xfail(raises=FileNotFoundError),
+        ),
         pytest.param(
             "example.txt",
             None,


### PR DESCRIPTION

### Link to Relevant Issue

This pull request resolves #
https://github.com/bioio-devs/bioio-bioformats/issues/21
### Description of Changes

Remove try-catch block so exceptions will rise.  Convert 'false' return to exception so the failure will include information.
Add a unit test around 'FileNotFound' since that came up elsewhere in bioio issues.
