### PR TITLE
bugfix/jint-typing

### DIFF
--- a/bioio_bioformats/biofile.py
+++ b/bioio_bioformats/biofile.py
@@ -191,7 +191,8 @@ class BioFile:
         if series is not None:
             self._r.setSeries(series)
 
-        nt, nc, nz, ny, nx, nrgb = self.core_meta.shape
+        # Normalize to ints
+        nt, nc, nz, ny, nx, nrgb = map(int, self.core_meta.shape)
 
         if self.dask_tiles:
             chunks = utils._get_dask_tile_chunks(nt, nc, nz, ny, nx, self.tile_size)

--- a/bioio_bioformats/tests/resources/jint_typing.tiff
+++ b/bioio_bioformats/tests/resources/jint_typing.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58119776b7460346681e2d0f22056f4f9a7808e16f78f6840d602480ed8289d3
+size 6317994


### PR DESCRIPTION
## Description 

The purpose of this PR is to add some type mapping to our `_to_dask()` function to avoid type mismatching as described in #40. This PR also adds a test and resource test file for this case.