### PR TITLE
Admin: Fix invalid parametrize argnames breaking CI test collection

### DIFF
--- a/bioio_bioformats/tests/test_reader.py
+++ b/bioio_bioformats/tests/test_reader.py
@@ -438,7 +438,7 @@ def test_resolution_levels() -> None:
     assert reader.shape == (2, 2, 3, 243, 473)
 
 
-@pytest.mark.parametrize("filename, ", ["CMU-1-Small-Region.svs"])
+@pytest.mark.parametrize("filename", ["CMU-1-Small-Region.svs"])
 def test_bioformats_dask_tiling_shapes(filename: str) -> None:
     # Construct full filepath
     uri = LOCAL_RESOURCES_DIR / filename
@@ -464,10 +464,10 @@ def test_bioformats_dask_tiling_shapes(filename: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "filename, ",
+    "filename",
     [
-        ("s_1_t_1_c_10_z_1.ome.tiff"),
-        #  ("CMU-1-Small-Region.svs")
+        "s_1_t_1_c_10_z_1.ome.tiff",
+        #  "CMU-1-Small-Region.svs"
     ],
 )
 def test_bioformats_dask_tiling_read(filename: str) -> None:


### PR DESCRIPTION
## Summary

Fixes the CI failure

## Root cause

Two `@pytest.mark.parametrize` calls in `test_reader.py` used a trailing comma in the names string: `"filename, "`. Newer pytest versions treat this as expecting **multiple** argnames. With single scalar string values, pytest then unpacks each string into its individual characters, producing:

Fixes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)