### PR TITLE
Fix pytest parametrization for filename

### DIFF
--- a/bioio_bioformats/tests/test_reader.py
+++ b/bioio_bioformats/tests/test_reader.py
@@ -464,7 +464,7 @@ def test_bioformats_dask_tiling_shapes(filename: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "filename, ",
+    "filename",
     [
         ("s_1_t_1_c_10_z_1.ome.tiff"),
         #  ("CMU-1-Small-Region.svs")

--- a/bioio_bioformats/tests/test_reader.py
+++ b/bioio_bioformats/tests/test_reader.py
@@ -438,7 +438,7 @@ def test_resolution_levels() -> None:
     assert reader.shape == (2, 2, 3, 243, 473)
 
 
-@pytest.mark.parametrize("filename, ", ["CMU-1-Small-Region.svs"])
+@pytest.mark.parametrize("filename", ["CMU-1-Small-Region.svs"])
 def test_bioformats_dask_tiling_shapes(filename: str) -> None:
     # Construct full filepath
     uri = LOCAL_RESOURCES_DIR / filename


### PR DESCRIPTION
## Summary
- remove the trailing comma from the filename parametrization
- fixes pytest collection error reported in #54

## Validation
- `uv run --with pytest pytest --collect-only bioio_bioformats/tests/test_reader.py`